### PR TITLE
KIT-1094 Publish package with vulnerability fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "static-expiry",
+  "name": "@pulse/static-expiry",
   "version": "1.0.2",
   "description": "Connect middleware for static files that sets caching response headers as well as generates and rewrites fingerprinted urls.",
   "keywords": [


### PR DESCRIPTION
This upgrades the fresh dependency to >= 0.5.2

│ High          │ Regular Expression Denial of Service                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ fresh                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >= 0.5.2                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ static-expiry                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ static-expiry > fresh                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/526               